### PR TITLE
Fix parsing of PHP_CodeSniffer output

### DIFF
--- a/src/Tools/PhpCodeSniffer.php
+++ b/src/Tools/PhpCodeSniffer.php
@@ -26,7 +26,7 @@ class PhpCodeSniffer extends Tool
             return true;
         }
 
-        $json = self::parseJson($output[end($output)]);
+        $json = self::parseJson(end($output));
         $result = new Result();
 
         foreach (($json['files'] ?? []) as $fileName => $details) {


### PR DESCRIPTION
In commit 2fef12b "Fix psalm errors" the code to get the last line of
the generated output was modified to work around psalm diagnostics, but
in a way that actually broke its functionality. The `end()` function
already returns the last element of an array, its return value is not
meant to be used to index that array.