### PR TITLE
chore: Using ${var} in strings is deprecated, use {$var} instead

### DIFF
--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -194,11 +194,11 @@ class RunCommand extends Command
             $timeTaken = '<gray>' . Helper::formatTime(time() - $start) . '</gray>';
 
             if ($result) {
-                $output->writeln("✔ {$name}: <info>OK</info> ${timeTaken}");
+                $output->writeln("✔ {$name}: <info>OK</info> {$timeTaken}");
                 continue;
             }
 
-            $output->writeln("<fg=red>✘</> {$name}: <fg=red>FAIL</> ${timeTaken}");
+            $output->writeln("<fg=red>✘</> {$name}: <fg=red>FAIL</> {$timeTaken}");
 
             $success = false;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -149,7 +149,7 @@ class Config
                 // or we've already loaded its contents
                 if (array_key_exists($includePath, $configs)) {
                     $this->output->writeln(
-                        "Cyclic dependency found at ${path} for ${includePath}",
+                        "Cyclic dependency found at {$path} for {$includePath}",
                         Output::VERBOSITY_NORMAL
                     );
                     continue;

--- a/src/Formatter/ConsoleFormatter.php
+++ b/src/Formatter/ConsoleFormatter.php
@@ -76,7 +76,7 @@ class ConsoleFormatter implements Formatter
 
         $results = implode(', ', array_map(
             static function (int $count, string $key): string {
-                return "${count} ${key}(s)";
+                return "{$count} {$key}(s)";
             },
             $counts,
             array_keys($counts)

--- a/src/Tools/EasyCodingStandard.php
+++ b/src/Tools/EasyCodingStandard.php
@@ -117,7 +117,7 @@ class EasyCodingStandard extends Tool
                 preg_replace('/(?<!^)[A-Z]/', ' $0', $withoutSuffix) ?? $withoutSuffix
             );
 
-            return $name . " <gray>(${checker})</gray>";
+            return $name . " <gray>({$checker})</gray>";
         }, $applied_checkers);
     }
 }

--- a/src/Tools/Phan.php
+++ b/src/Tools/Phan.php
@@ -45,7 +45,7 @@ class Phan extends Tool
             $violation->message = $entry['description'];
             $violation->tool = $this->name;
             $violation->line = $entry['location']['lines']['begin'];
-            $violation->source = "${entry['check_name']} (${entry['type_id']})";
+            $violation->source = "{$entry['check_name']} ({$entry['type_id']})";
 
             $file = new File();
             $file->violations[] = $violation;

--- a/src/Tools/Psalm.php
+++ b/src/Tools/Psalm.php
@@ -39,7 +39,7 @@ class Psalm extends Tool
         $exitCode = $this->execute($binary, array_merge(
             [
                 '--monochrome',
-                "--report=${tmpFileJson}",
+                "--report={$tmpFileJson}",
                 '--no-progress',
             ],
             $config,
@@ -68,7 +68,7 @@ class Psalm extends Tool
             $violation->message = $entry['message'];
             $violation->tool = $this->name;
             $violation->line = $entry['line_from'];
-            $violation->source = "${entry['type']} (${entry['link']})";
+            $violation->source = "{$entry['type']} ({$entry['link']})";
             $violation->severity = $entry['severity'] === Violation::SEVERITY_ERROR
                 ? Violation::SEVERITY_ERROR
                 : Violation::SEVERITY_WARNING;
@@ -98,6 +98,6 @@ class Psalm extends Tool
             ? dirname($binary, 3) . DIRECTORY_SEPARATOR . $configName
             : $configName;
 
-        return file_exists($configName) ? ["--config=${configName}"] : [];
+        return file_exists($configName) ? ["--config={$configName}"] : [];
     }
 }

--- a/src/Tools/Rector.php
+++ b/src/Tools/Rector.php
@@ -75,7 +75,7 @@ class Rector extends Tool
 
             $name = strtolower(preg_replace('/(?<!^)[A-Z]/', ' $0', $withoutSuffix));
 
-            return $name . " <gray>(${rector})</gray>";
+            return $name . " <gray>({$rector})</gray>";
         }, $applied_rectors);
     }
 }

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -134,7 +134,7 @@ abstract class Tool
         $binary = PHPCSTD_BINARY_PATH . $binary;
 
         if (! is_file($binary)) {
-            $binary = "${binary}.phar";
+            $binary = "{$binary}.phar";
         }
 
         if (Cli::isOnWindows()) {
@@ -152,7 +152,7 @@ abstract class Tool
             throw new RuntimeException('Unable to create temporary report file');
         }
 
-        $tmpFileJson = "${tmpFile}.json";
+        $tmpFileJson = "{$tmpFile}.json";
 
         if (! rename($tmpFile, $tmpFileJson)) {
             throw new RuntimeException('Unable to rename temporary report file');


### PR DESCRIPTION
```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Commands/RunCommand.php on line 197
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Commands/RunCommand.php on line 201
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Tool.php on line 137
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Tool.php on line 155
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Rector.php on line 78
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/EasyCodingStandard.php on line 120
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Psalm.php on line 42
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Psalm.php on line 71
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Psalm.php on line 71
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Psalm.php on line 101
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Phan.php on line 48
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Tools/Phan.php on line 48
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Config.php on line 152
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/spaceemotion/php-coding-standard/src/Config.php on line 152
```